### PR TITLE
Fix config file error message

### DIFF
--- a/src/main/java/com/norwood/core/FileConfigManager.java
+++ b/src/main/java/com/norwood/core/FileConfigManager.java
@@ -26,7 +26,7 @@ public class FileConfigManager implements ConfigManager {
         try {
             return Files.lines(Path.of(configFile));
         } catch (IOException e) {
-            throw new RuntimeException("No config file found at: " + configMap);
+            throw new RuntimeException("No config file found at: " + configFile);
         }
     }
 


### PR DESCRIPTION
## Summary
- correct the missing-config message in FileConfigManager

## Testing
- `mvn` not installed, so no tests run