### PR TITLE
Add HttpRequest roundtrip test

### DIFF
--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -4,6 +4,10 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+import java.net.http.HttpRequest;
+
+import com.norwood.util.HttpRequestSerializer;
+
 public class AppTest 
     extends TestCase
 {
@@ -14,7 +18,14 @@ public class AppTest
 
     public static Test suite()
     {
-        assertTrue(true);
         return new TestSuite( AppTest.class );
+    }
+
+    public void testSerializeUnserializeRoundtrip() {
+        String line = "GET /hello HTTP/1.1";
+        HttpRequest req = HttpRequestSerializer.unserialize(line);
+        assertEquals("GET", req.method());
+        assertEquals("/hello", req.uri().getPath());
+        assertEquals(line, HttpRequestSerializer.serialize(req));
     }
 }


### PR DESCRIPTION
## Summary
- update the AppTest suite to remove a no-op assertion
- add a roundtrip test that verifies HttpRequestSerializer

## Testing
- `mvn -q test` *(fails: `mvn` not found)*