### PR TITLE
Add more unit tests

### DIFF
--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -5,6 +5,7 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import java.net.http.HttpRequest;
+import java.net.URI;
 
 import com.norwood.util.HttpRequestSerializer;
 
@@ -27,5 +28,17 @@ public class AppTest
         assertEquals("GET", req.method());
         assertEquals("/hello", req.uri().getPath());
         assertEquals(line, HttpRequestSerializer.serialize(req));
+    }
+
+    public void testGetPathWithQueryAndFragment() {
+        URI uri = URI.create("https://example.com/foo?bar=1#frag");
+        assertEquals("/foo?bar=1#frag", HttpRequestSerializer.getPath(uri));
+    }
+
+    public void testUnserializeAbsoluteUrl() {
+        String line = "GET https://example.com/abs HTTP/1.1";
+        HttpRequest req = HttpRequestSerializer.unserialize(line);
+        assertEquals("https://example.com/abs", req.uri().toString());
+        assertEquals("/abs", HttpRequestSerializer.getPath(req.uri()));
     }
 }

--- a/src/test/java/com/norwood/core/FileConfigManagerTest.java
+++ b/src/test/java/com/norwood/core/FileConfigManagerTest.java
@@ -1,0 +1,13 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class FileConfigManagerTest extends TestCase {
+    public void testGetReturnsConfigValue() {
+        FileConfigManager manager = new FileConfigManager();
+        String val = manager.get("beanRegistryClass");
+        assertEquals("com.norwood.userland.UserBeanRegistry", val);
+        // second call should return same value from cache
+        assertEquals(val, manager.get("beanRegistryClass"));
+    }
+}

--- a/src/test/java/com/norwood/core/KatanaContainerTest.java
+++ b/src/test/java/com/norwood/core/KatanaContainerTest.java
@@ -1,0 +1,22 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class KatanaContainerTest extends TestCase {
+    public void testSetAndGet() {
+        KatanaContainer container = new KatanaContainer();
+        container.set(String.class, "hello");
+        assertEquals("hello", container.get(String.class));
+    }
+
+    public void testSetTwiceThrows() {
+        KatanaContainer container = new KatanaContainer();
+        container.set(Integer.class, 1);
+        try {
+            container.set(Integer.class, 2);
+            fail("Expected ContainerException");
+        } catch (ContainerException e) {
+            // expected
+        }
+    }
+}

--- a/src/test/java/com/norwood/core/KatanaResponseTest.java
+++ b/src/test/java/com/norwood/core/KatanaResponseTest.java
@@ -1,0 +1,12 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class KatanaResponseTest extends TestCase {
+    public void testSuccessAndError() {
+        KatanaResponse success = KatanaResponse.success(123);
+        assertEquals("123", success.value());
+        KatanaResponse err = KatanaResponse.error("fail");
+        assertEquals("fail", err.value());
+    }
+}

--- a/src/test/java/com/norwood/routing/RouteTest.java
+++ b/src/test/java/com/norwood/routing/RouteTest.java
@@ -1,0 +1,21 @@
+package com.norwood.routing;
+
+import junit.framework.TestCase;
+
+public class RouteTest extends TestCase {
+    public void testHttpMethodFromString() {
+        assertEquals(Route.HttpMethod.GET, Route.HttpMethod.fromString("get"));
+        assertEquals(Route.HttpMethod.POST, Route.HttpMethod.fromString("POST"));
+    }
+
+    public void testOfPathAndToString() {
+        Route r = Route.get("/x", (o, req) -> "ok");
+        assertTrue(r.ofPath("/x"));
+        assertTrue(r.toString().contains("GET /x"));
+    }
+
+    public void testOfPathFalse() {
+        Route r = Route.post("/y", (o, req) -> "a");
+        assertFalse(r.ofPath("/x"));
+    }
+}

--- a/src/test/java/com/norwood/routing/RouterTest.java
+++ b/src/test/java/com/norwood/routing/RouterTest.java
@@ -1,0 +1,27 @@
+package com.norwood.routing;
+
+import com.norwood.core.KatanaCore;
+import com.norwood.userland.UserController;
+import junit.framework.TestCase;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class RouterTest extends TestCase {
+    public void testDefineAndHasRoute() {
+        Router r = new Router();
+        r.defineRoute(Route.get("/a", (o, req) -> "ok"));
+        assertTrue(r.hasRouteWithPath("/a"));
+        assertFalse(r.hasRouteWithPath("/b"));
+    }
+
+    public void testRouteCallsHandler() {
+        Router r = new Router();
+        if (KatanaCore.container.get(UserController.class) == null) {
+            KatanaCore.container.set(UserController.class, new UserController());
+        }
+        r.defineRoute(Route.get("/c", (o, req) -> "res"));
+        HttpRequest req = HttpRequest.newBuilder().uri(URI.create("http://x/c")).GET().build();
+        assertEquals("res", r.route(req));
+    }
+}

--- a/src/test/java/com/norwood/userland/AnnotationProcessorTest.java
+++ b/src/test/java/com/norwood/userland/AnnotationProcessorTest.java
@@ -1,0 +1,27 @@
+package com.norwood.userland;
+
+import com.norwood.core.AnnotationProcessor;
+import com.norwood.core.KatanaCore;
+import com.norwood.routing.Router;
+import junit.framework.TestCase;
+
+public class AnnotationProcessorTest extends TestCase {
+    public void testProcessAnnotationsInjectsAndRegistersRoutes() {
+        if (KatanaCore.container.get(UserController.class) == null) {
+            KatanaCore.container.set(UserController.class, new UserController());
+        }
+
+        AnnotationProcessor ap = new AnnotationProcessor();
+        Router router = new Router();
+
+        ap.processAnnotations(KatanaCore.container.classDefinitions(), router);
+
+        UserController ctrl = KatanaCore.container.get(UserController.class);
+        assertNotNull(ctrl.userService);
+        assertNotNull(ctrl.scraper);
+        assertTrue(router.hasRouteWithPath("/test1"));
+        assertTrue(router.hasRouteWithPath("/test2"));
+        assertTrue(router.hasRouteWithPath("/test3"));
+        assertTrue(router.hasRouteWithPath("/scrape"));
+    }
+}


### PR DESCRIPTION
## Summary
- extend HttpRequestSerializer tests
- add tests for container, routing, config manager, and response
- test annotation processor for dependency injection

## Testing
- `mvn test` *(fails: `mvn: command not found`)*