### PR TITLE
Add stub FHIR ingestion service

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ IntegrationFlow katanaFlow = Katana.flow()
 
 ---
 
+## FHIR Ingestion Service
+
+Katana includes a simple `FhirIngestionService` capable of reading a FHIR Bundle
+from a JSON string or file. The service can be triggered through the new `/fhir-
+ingest` endpoint.
+
+Example usage:
+
+```bash
+curl -X POST "http://localhost:8082/fhir-ingest?file=resources/bundle.json"
+```
+
+When invoked, the service will parse the bundle (using a stubbed parser) and
+return a `PatientRecord` representation.
+
+---
+
 ## Documentation
 
 - [Katana Quick Start Guide (Coming Soon)]()

--- a/src/main/java/com/norwood/pipeline/fhir/FhirIngestionService.java
+++ b/src/main/java/com/norwood/pipeline/fhir/FhirIngestionService.java
@@ -1,0 +1,72 @@
+package com.norwood.pipeline.fhir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Service responsible for ingesting a FHIR Bundle provided as a JSON string or
+ * file. For simplicity this implementation uses a stubbed parser to extract
+ * minimal information and transform it into a {@link PatientRecord}.
+ */
+public class FhirIngestionService {
+
+    public PatientRecord ingestFromString(String bundleJson) {
+        FhirBundle bundle = parseBundle(bundleJson);
+        return transform(bundle);
+    }
+
+    public PatientRecord ingestFromFile(Path file) {
+        try {
+            String json = Files.readString(file);
+            return ingestFromString(json);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read bundle file", e);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helper types and methods
+    // ---------------------------------------------------------------------
+
+    private PatientRecord transform(FhirBundle bundle) {
+        return new PatientRecord(bundle.id, bundle.rawJson);
+    }
+
+    /**
+     * Stubbed parser that attempts to extract a bundle id from the JSON string.
+     * In a real implementation this would leverage a library such as HAPI FHIR.
+     */
+    private FhirBundle parseBundle(String json) {
+        String id = extractId(json);
+        return new FhirBundle(id, json);
+    }
+
+    private String extractId(String json) {
+        try {
+            int idx = json.indexOf("\"id\"");
+            if (idx >= 0) {
+                int colon = json.indexOf(':', idx);
+                int start = json.indexOf('"', colon + 1);
+                int end = json.indexOf('"', start + 1);
+                if (start > -1 && end > -1) {
+                    return json.substring(start + 1, end);
+                }
+            }
+        } catch (Exception e) {
+            // ignore and fall through to default
+        }
+        return "unknown";
+    }
+
+    // simple container for parsed bundle fields
+    private static class FhirBundle {
+        final String id;
+        final String rawJson;
+
+        FhirBundle(String id, String rawJson) {
+            this.id = id;
+            this.rawJson = rawJson;
+        }
+    }
+}

--- a/src/main/java/com/norwood/pipeline/fhir/PatientRecord.java
+++ b/src/main/java/com/norwood/pipeline/fhir/PatientRecord.java
@@ -1,0 +1,30 @@
+package com.norwood.pipeline.fhir;
+
+/**
+ * Simple model representing a patient record derived from a FHIR Bundle.
+ */
+public class PatientRecord {
+    private final String id;
+    private final String source;
+
+    public PatientRecord(String id, String source) {
+        this.id = id;
+        this.source = source;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public String toString() {
+        return "PatientRecord{" +
+            "id='" + id + '\'' +
+            ", source='" + source + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/com/norwood/userland/UserBeanRegistry.java
+++ b/src/main/java/com/norwood/userland/UserBeanRegistry.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.norwood.core.KatanaCore;
 import com.norwood.core.UserlandBeanRegistry;
+import com.norwood.pipeline.fhir.FhirIngestionService;
 
 public class UserBeanRegistry implements UserlandBeanRegistry {
     @SuppressWarnings("unchecked")
@@ -11,10 +12,11 @@ public class UserBeanRegistry implements UserlandBeanRegistry {
         List.of(
             (T) new UserController(),
             (T) new UserService(),
-            (T) new Scraper()
+            (T) new Scraper(),
+            (T) new FhirIngestionService()
         ).forEach(b -> KatanaCore.container.set(
             (Class<T>) b.getClass(),
             (T) b)
-        ); 
+        );
     }
 }

--- a/src/main/java/com/norwood/userland/UserController.java
+++ b/src/main/java/com/norwood/userland/UserController.java
@@ -8,11 +8,14 @@ import com.norwood.core.Singleton;
 import com.norwood.core.annotations.Inject;
 import com.norwood.routing.annotation.Get;
 import com.norwood.routing.annotation.Post;
+import com.norwood.pipeline.fhir.FhirIngestionService;
+import com.norwood.pipeline.fhir.PatientRecord;
 
 @Singleton
 public class UserController {
     @Inject UserService userService;
     @Inject Scraper scraper;
+    @Inject FhirIngestionService fhirService;
 
     @Post(path = "/test1")
     public int route1(HttpRequest request) {
@@ -28,6 +31,18 @@ public class UserController {
     @Get(path = "/test3")
     public String userServiceTest(HttpRequest request) {
         return userService.userMethod();
+    }
+
+    @Post(path = "/fhir-ingest")
+    public String fhirIngest(HttpRequest request) {
+        String query = request.uri().getQuery();
+        if (query != null && query.startsWith("file=")) {
+            Path file = Path.of(query.substring("file=".length()));
+            PatientRecord pr = fhirService.ingestFromFile(file);
+            return pr.toString();
+        }
+        PatientRecord pr = fhirService.ingestFromString("{\"id\":\"demo\"}");
+        return pr.toString();
     }
 
     @Get(path = "/test2")


### PR DESCRIPTION
## Summary
- create new package `com.norwood.pipeline.fhir`
- implement `FhirIngestionService` and `PatientRecord` model
- register `FhirIngestionService` in `UserBeanRegistry`
- expose `/fhir-ingest` endpoint in `UserController`
- document the service in README

## Testing
- `javac --release 21 --enable-preview @sources.txt`
- `javac --class-path src/main/java --release 21 --enable-preview @test_sources.txt` *(fails: junit framework missing)*