### PR TITLE
Handle annotations for more HTTP methods

### DIFF
--- a/src/main/java/com/norwood/core/AnnotationProcessor.java
+++ b/src/main/java/com/norwood/core/AnnotationProcessor.java
@@ -13,6 +13,11 @@ import com.norwood.routing.Route;
 import com.norwood.routing.Router;
 import com.norwood.routing.annotation.Get;
 import com.norwood.routing.annotation.Post;
+import com.norwood.routing.annotation.Put;
+import com.norwood.routing.annotation.Delete;
+import com.norwood.routing.annotation.Patch;
+import com.norwood.routing.annotation.Head;
+import com.norwood.routing.annotation.Options;
 
 public class AnnotationProcessor {
     public void processAnnotations(List<Class<?>> classDefinitions, Router router) {
@@ -31,6 +36,11 @@ public class AnnotationProcessor {
                     switch (an) {
                         case Get a -> routeGet(a, router, method);
                         case Post a -> routePost(a, router, method);
+                        case Put a -> routePut(a, router, method);
+                        case Delete a -> routeDelete(a, router, method);
+                        case Patch a -> routePatch(a, router, method);
+                        case Head a -> routeHead(a, router, method);
+                        case Options a -> routeOptions(a, router, method);
                         default -> System.out.println("Unknown annotation: " + an.toString());
                     }
                 }
@@ -60,7 +70,7 @@ public class AnnotationProcessor {
 
     private void routePost(Post a, Router router, Method method) {
         String path = a.path();
-        if (router.hasRouteWithPath(path)) {
+        if (router.hasRoute(path, Route.HttpMethod.POST)) {
             throw new RuntimeException("Route already defined with path: " + path);
         }
 
@@ -69,11 +79,56 @@ public class AnnotationProcessor {
 
     private void routeGet(Get a, Router router, Method method) {
         String path = a.path();
-        if (router.hasRouteWithPath(path)) {
+        if (router.hasRoute(path, Route.HttpMethod.GET)) {
             throw new RuntimeException("Route already defined with path: " + path);
         }
 
         router.defineRoute(Route.get(path, createHandler(method)));
+    }
+
+    private void routePut(Put a, Router router, Method method) {
+        String path = a.path();
+        if (router.hasRoute(path, Route.HttpMethod.PUT)) {
+            throw new RuntimeException("Route already defined with path: " + path);
+        }
+
+        router.defineRoute(Route.put(path, createHandler(method)));
+    }
+
+    private void routeDelete(Delete a, Router router, Method method) {
+        String path = a.path();
+        if (router.hasRoute(path, Route.HttpMethod.DELETE)) {
+            throw new RuntimeException("Route already defined with path: " + path);
+        }
+
+        router.defineRoute(Route.delete(path, createHandler(method)));
+    }
+
+    private void routePatch(Patch a, Router router, Method method) {
+        String path = a.path();
+        if (router.hasRoute(path, Route.HttpMethod.PATCH)) {
+            throw new RuntimeException("Route already defined with path: " + path);
+        }
+
+        router.defineRoute(Route.patch(path, createHandler(method)));
+    }
+
+    private void routeHead(Head a, Router router, Method method) {
+        String path = a.path();
+        if (router.hasRoute(path, Route.HttpMethod.HEAD)) {
+            throw new RuntimeException("Route already defined with path: " + path);
+        }
+
+        router.defineRoute(Route.head(path, createHandler(method)));
+    }
+
+    private void routeOptions(Options a, Router router, Method method) {
+        String path = a.path();
+        if (router.hasRoute(path, Route.HttpMethod.OPTIONS)) {
+            throw new RuntimeException("Route already defined with path: " + path);
+        }
+
+        router.defineRoute(Route.options(path, createHandler(method)));
     }
 
     private Container container() {

--- a/src/main/java/com/norwood/routing/Route.java
+++ b/src/main/java/com/norwood/routing/Route.java
@@ -10,7 +10,9 @@ public class Route {
         POST,
         PUT,
         DELETE,
-        PATCH;
+        PATCH,
+        HEAD,
+        OPTIONS;
 
         public static HttpMethod fromString(String method) {
             if (method == null) {
@@ -43,12 +45,40 @@ public class Route {
         return this.path.equals(path);
     }
 
+    public boolean matches(String method, String path) {
+        return this.method == HttpMethod.fromString(method) && ofPath(path);
+    }
+
+    public HttpMethod method() {
+        return method;
+    }
+
     public static Route get(String name, BiFunction<Object, HttpRequest, Object> handler) {
         return Route.create(HttpMethod.GET, name, handler);
     }
 
     public static Route post(String name, BiFunction<Object, HttpRequest, Object> handler) {
         return Route.create(HttpMethod.POST, name, handler);
+    }
+
+    public static Route put(String name, BiFunction<Object, HttpRequest, Object> handler) {
+        return Route.create(HttpMethod.PUT, name, handler);
+    }
+
+    public static Route delete(String name, BiFunction<Object, HttpRequest, Object> handler) {
+        return Route.create(HttpMethod.DELETE, name, handler);
+    }
+
+    public static Route patch(String name, BiFunction<Object, HttpRequest, Object> handler) {
+        return Route.create(HttpMethod.PATCH, name, handler);
+    }
+
+    public static Route head(String name, BiFunction<Object, HttpRequest, Object> handler) {
+        return Route.create(HttpMethod.HEAD, name, handler);
+    }
+
+    public static Route options(String name, BiFunction<Object, HttpRequest, Object> handler) {
+        return Route.create(HttpMethod.OPTIONS, name, handler);
     }
 
     @Override

--- a/src/main/java/com/norwood/routing/Router.java
+++ b/src/main/java/com/norwood/routing/Router.java
@@ -12,17 +12,17 @@ public class Router {
 
     public Object route(HttpRequest request) {
         System.out.println(resolveController());
-        return findRouteByPath(request).handler().apply(resolveController(), request);
+        return findRoute(request.method(), request.uri().getRawPath())
+            .handler().apply(resolveController(), request);
     }
 
     private UserController resolveController() {
         return KatanaCore.container.get(UserController.class);
     }
 
-    private Route findRouteByPath(HttpRequest request) {
-        String path = request.uri().getRawPath();
+    private Route findRoute(String method, String path) {
         return routes.stream()
-                .filter(r -> r.ofPath(path))
+                .filter(r -> r.matches(method, path))
                 .findFirst().orElseThrow();
     }
 
@@ -32,6 +32,10 @@ public class Router {
 
     public void defineRoutes(List<Route> other) {
         routes.addAll(other);
+    }
+
+    public boolean hasRoute(String path, Route.HttpMethod method) {
+        return routes.stream().anyMatch(r -> r.ofPath(path) && r.method() == method);
     }
 
     public boolean hasRouteWithPath(String path) {

--- a/src/main/java/com/norwood/routing/annotation/Delete.java
+++ b/src/main/java/com/norwood/routing/annotation/Delete.java
@@ -1,0 +1,12 @@
+package com.norwood.routing.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Delete {
+    String path();
+}

--- a/src/main/java/com/norwood/routing/annotation/Head.java
+++ b/src/main/java/com/norwood/routing/annotation/Head.java
@@ -1,0 +1,12 @@
+package com.norwood.routing.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Head {
+    String path();
+}

--- a/src/main/java/com/norwood/routing/annotation/Options.java
+++ b/src/main/java/com/norwood/routing/annotation/Options.java
@@ -1,0 +1,12 @@
+package com.norwood.routing.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Options {
+    String path();
+}

--- a/src/main/java/com/norwood/routing/annotation/Patch.java
+++ b/src/main/java/com/norwood/routing/annotation/Patch.java
@@ -1,0 +1,12 @@
+package com.norwood.routing.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Patch {
+    String path();
+}

--- a/src/main/java/com/norwood/routing/annotation/Put.java
+++ b/src/main/java/com/norwood/routing/annotation/Put.java
@@ -1,0 +1,12 @@
+package com.norwood.routing.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Put {
+    String path();
+}

--- a/src/main/java/com/norwood/util/HttpRequestSerializer.java
+++ b/src/main/java/com/norwood/util/HttpRequestSerializer.java
@@ -21,7 +21,7 @@ public class HttpRequestSerializer
 
         return HttpRequest.newBuilder()
             .uri(URI.create(uriString))
-            .GET()
+            .method(method, HttpRequest.BodyPublishers.noBody())
             .build();
     }
 

--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -28,4 +28,14 @@ public class AppTest
         assertEquals("/hello", req.uri().getPath());
         assertEquals(line, HttpRequestSerializer.serialize(req));
     }
+
+    public void testUnserializeAllMethods() {
+        String[] methods = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"};
+        for (String method : methods) {
+            String line = method + " /test HTTP/1.1";
+            HttpRequest req = HttpRequestSerializer.unserialize(line);
+            assertEquals(method, req.method());
+            assertEquals(line, HttpRequestSerializer.serialize(req));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend `HttpMethod` enum with HEAD and OPTIONS
- add static factories for all HTTP methods in `Route`
- track HTTP method when routing and when detecting duplicates
- implement annotation classes and handling for PUT, DELETE, PATCH, HEAD and OPTIONS

## Testing
- `javac --release 21 --enable-preview @sources.txt`
- `mvn -v` *(fails: command not found)*