### PR TITLE
Implement 404 handling in router

### DIFF
--- a/src/main/java/com/norwood/core/KatanaCore.java
+++ b/src/main/java/com/norwood/core/KatanaCore.java
@@ -29,7 +29,11 @@ public class KatanaCore {
 
     public KatanaResponse handleRequest(HttpRequest req) {
         try {
-            return KatanaResponse.success(router.route(req));
+            Object result = router.route(req);
+            if (result == null) {
+                return KatanaResponse.error("Not Found");
+            }
+            return KatanaResponse.success(result);
         } catch (Exception e) {
             return KatanaResponse.error("Katana response processing error");
         }

--- a/src/main/java/com/norwood/routing/Router.java
+++ b/src/main/java/com/norwood/routing/Router.java
@@ -3,6 +3,7 @@ package com.norwood.routing;
 import java.net.http.HttpRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.norwood.core.KatanaCore;
 import com.norwood.userland.UserController;
@@ -11,19 +12,22 @@ public class Router {
     final List<Route> routes = new ArrayList<>();
 
     public Object route(HttpRequest request) {
-        System.out.println(resolveController());
-        return findRoute(request.method(), request.uri().getRawPath())
-            .handler().apply(resolveController(), request);
+        Optional<Route> maybeRoute = findRoute(request.method(), request.uri().getRawPath());
+        if (maybeRoute.isPresent()) {
+            System.out.println(resolveController());
+            return maybeRoute.get().handler().apply(resolveController(), request);
+        }
+        return null;
     }
 
     private UserController resolveController() {
         return KatanaCore.container.get(UserController.class);
     }
 
-    private Route findRoute(String method, String path) {
+    private Optional<Route> findRoute(String method, String path) {
         return routes.stream()
                 .filter(r -> r.matches(method, path))
-                .findFirst().orElseThrow();
+                .findFirst();
     }
 
     public void defineRoute(Route route) {

--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -7,6 +7,8 @@ import junit.framework.TestSuite;
 import java.net.http.HttpRequest;
 
 import com.norwood.util.HttpRequestSerializer;
+import com.norwood.core.KatanaCore;
+import com.norwood.core.KatanaResponse;
 
 public class AppTest 
     extends TestCase
@@ -37,5 +39,12 @@ public class AppTest
             assertEquals(method, req.method());
             assertEquals(line, HttpRequestSerializer.serialize(req));
         }
+    }
+
+    public void testHandleRequestNotFound() {
+        KatanaCore core = new KatanaCore();
+        HttpRequest req = HttpRequestSerializer.unserialize("GET /missing HTTP/1.1");
+        KatanaResponse res = core.handleRequest(req);
+        assertEquals("Not Found", res.value());
     }
 }


### PR DESCRIPTION
## Summary
- return `Optional` from `Router.findRoute`
- handle missing routes in `Router.route` and `KatanaCore.handleRequest`
- add a unit test showing 404 behavior

## Testing
- `javac --release 21 --enable-preview @sources.txt -d /tmp/katana_classes`
- `javac --release 21 --enable-preview -cp /tmp/katana_classes @test_sources.txt -d /tmp/katana_test_classes` *(fails: package junit.framework does not exist)*