### PR TITLE
Fix debug output and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/*
 .settings
 .git
 
+a.out

--- a/src/main/java/com/norwood/core/AnnotationProcessor.java
+++ b/src/main/java/com/norwood/core/AnnotationProcessor.java
@@ -19,10 +19,11 @@ public class AnnotationProcessor {
         for (Class<?> userClass : classDefinitions) {
             for (Field field : userClass.getDeclaredFields()) {
                 for (Annotation an : field.getDeclaredAnnotations()) {
-                    System.out.println("Anno: " + an.getClass());
                     switch (an) {
                         case Inject _ -> inject(field);
-                        default -> System.out.println("Unknown annotation: " + an.toString());
+                        default -> {
+                            /* ignored */
+                        }
                     }
                 }
             }
@@ -31,7 +32,9 @@ public class AnnotationProcessor {
                     switch (an) {
                         case Get a -> routeGet(a, router, method);
                         case Post a -> routePost(a, router, method);
-                        default -> System.out.println("Unknown annotation: " + an.toString());
+                        default -> {
+                            /* ignored */
+                        }
                     }
                 }
             }
@@ -46,9 +49,6 @@ public class AnnotationProcessor {
 
             field.setAccessible(true);
             field.set(owner, dependency);
-
-            System.out.println(owner);
-            System.out.println(dependency);
         } catch (InstantiationException  | 
                 IllegalAccessException | IllegalArgumentException |
                 InvocationTargetException | NoSuchMethodException e)
@@ -88,7 +88,6 @@ public class AnnotationProcessor {
         try {
             return method.invoke(instance, arg1);
         } catch (IllegalAccessException | InvocationTargetException e) {
-            System.out.println("Error invoking stuff...");
             e.printStackTrace();
             throw new RuntimeException("Failed executing method: " + method.getName());
          }

--- a/src/main/java/com/norwood/routing/Router.java
+++ b/src/main/java/com/norwood/routing/Router.java
@@ -11,7 +11,6 @@ public class Router {
     final List<Route> routes = new ArrayList<>();
 
     public Object route(HttpRequest request) {
-        System.out.println(resolveController());
         return findRouteByPath(request).handler().apply(resolveController(), request);
     }
 

--- a/src/main/java/com/norwood/userland/Scraper.java
+++ b/src/main/java/com/norwood/userland/Scraper.java
@@ -9,7 +9,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 
 public class Scraper {
     public void scrape() {
-        System.out.println("test");
+        // placeholder implementation
     }
 
     public void sendGetRequest(String uriStr) {

--- a/src/main/java/com/norwood/userland/UserController.java
+++ b/src/main/java/com/norwood/userland/UserController.java
@@ -16,7 +16,6 @@ public class UserController {
 
     @Post(path = "/test1")
     public int route1(HttpRequest request) {
-        System.out.println("[UserController] /test1 executed :" + request.method());
         return 1;
     }
 
@@ -32,7 +31,6 @@ public class UserController {
 
     @Get(path = "/test2")
     public String route2(HttpRequest request) {
-        System.out.println("[UserController] /test2 executed :" + request.method());
         try {
             return Files.readString(Path.of("resources/index.html"));
         } catch (IOException e) {

--- a/src/main/java/com/norwood/util/HttpRequestSerializer.java
+++ b/src/main/java/com/norwood/util/HttpRequestSerializer.java
@@ -6,7 +6,6 @@ import java.net.http.HttpRequest;
 public class HttpRequestSerializer
 {
     public static HttpRequest unserialize(String req) {
-        System.out.println("Got request: " + req);
         String[] httpRequest = req.split(" ");
 
         String method = httpRequest[0];

--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -5,6 +5,7 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import java.net.http.HttpRequest;
+import java.net.URI;
 
 import com.norwood.util.HttpRequestSerializer;
 
@@ -27,5 +28,17 @@ public class AppTest
         assertEquals("GET", req.method());
         assertEquals("/hello", req.uri().getPath());
         assertEquals(line, HttpRequestSerializer.serialize(req));
+    }
+
+    public void testGetPathWithQueryAndFragment() {
+        URI uri = URI.create("https://example.com/foo?bar=1#frag");
+        assertEquals("/foo?bar=1#frag", HttpRequestSerializer.getPath(uri));
+    }
+
+    public void testUnserializeAbsoluteUrl() {
+        String line = "GET https://example.com/abs HTTP/1.1";
+        HttpRequest req = HttpRequestSerializer.unserialize(line);
+        assertEquals("https://example.com/abs", req.uri().toString());
+        assertEquals("/abs", HttpRequestSerializer.getPath(req.uri()));
     }
 }

--- a/src/test/java/com/norwood/core/FileConfigManagerTest.java
+++ b/src/test/java/com/norwood/core/FileConfigManagerTest.java
@@ -1,0 +1,13 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class FileConfigManagerTest extends TestCase {
+    public void testGetReturnsConfigValue() {
+        FileConfigManager manager = new FileConfigManager();
+        String val = manager.get("beanRegistryClass");
+        assertEquals("com.norwood.userland.UserBeanRegistry", val);
+        // second call should return same value from cache
+        assertEquals(val, manager.get("beanRegistryClass"));
+    }
+}

--- a/src/test/java/com/norwood/core/KatanaContainerTest.java
+++ b/src/test/java/com/norwood/core/KatanaContainerTest.java
@@ -1,0 +1,22 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class KatanaContainerTest extends TestCase {
+    public void testSetAndGet() {
+        KatanaContainer container = new KatanaContainer();
+        container.set(String.class, "hello");
+        assertEquals("hello", container.get(String.class));
+    }
+
+    public void testSetTwiceThrows() {
+        KatanaContainer container = new KatanaContainer();
+        container.set(Integer.class, 1);
+        try {
+            container.set(Integer.class, 2);
+            fail("Expected ContainerException");
+        } catch (ContainerException e) {
+            // expected
+        }
+    }
+}

--- a/src/test/java/com/norwood/core/KatanaResponseTest.java
+++ b/src/test/java/com/norwood/core/KatanaResponseTest.java
@@ -1,0 +1,12 @@
+package com.norwood.core;
+
+import junit.framework.TestCase;
+
+public class KatanaResponseTest extends TestCase {
+    public void testSuccessAndError() {
+        KatanaResponse success = KatanaResponse.success(123);
+        assertEquals("123", success.value());
+        KatanaResponse err = KatanaResponse.error("fail");
+        assertEquals("fail", err.value());
+    }
+}

--- a/src/test/java/com/norwood/routing/RouteTest.java
+++ b/src/test/java/com/norwood/routing/RouteTest.java
@@ -1,0 +1,21 @@
+package com.norwood.routing;
+
+import junit.framework.TestCase;
+
+public class RouteTest extends TestCase {
+    public void testHttpMethodFromString() {
+        assertEquals(Route.HttpMethod.GET, Route.HttpMethod.fromString("get"));
+        assertEquals(Route.HttpMethod.POST, Route.HttpMethod.fromString("POST"));
+    }
+
+    public void testOfPathAndToString() {
+        Route r = Route.get("/x", (o, req) -> "ok");
+        assertTrue(r.ofPath("/x"));
+        assertTrue(r.toString().contains("GET /x"));
+    }
+
+    public void testOfPathFalse() {
+        Route r = Route.post("/y", (o, req) -> "a");
+        assertFalse(r.ofPath("/x"));
+    }
+}

--- a/src/test/java/com/norwood/routing/RouterTest.java
+++ b/src/test/java/com/norwood/routing/RouterTest.java
@@ -1,0 +1,27 @@
+package com.norwood.routing;
+
+import com.norwood.core.KatanaCore;
+import com.norwood.userland.UserController;
+import junit.framework.TestCase;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+
+public class RouterTest extends TestCase {
+    public void testDefineAndHasRoute() {
+        Router r = new Router();
+        r.defineRoute(Route.get("/a", (o, req) -> "ok"));
+        assertTrue(r.hasRouteWithPath("/a"));
+        assertFalse(r.hasRouteWithPath("/b"));
+    }
+
+    public void testRouteCallsHandler() {
+        Router r = new Router();
+        if (KatanaCore.container.get(UserController.class) == null) {
+            KatanaCore.container.set(UserController.class, new UserController());
+        }
+        r.defineRoute(Route.get("/c", (o, req) -> "res"));
+        HttpRequest req = HttpRequest.newBuilder().uri(URI.create("http://x/c")).GET().build();
+        assertEquals("res", r.route(req));
+    }
+}

--- a/src/test/java/com/norwood/userland/AnnotationProcessorTest.java
+++ b/src/test/java/com/norwood/userland/AnnotationProcessorTest.java
@@ -1,0 +1,27 @@
+package com.norwood.userland;
+
+import com.norwood.core.AnnotationProcessor;
+import com.norwood.core.KatanaCore;
+import com.norwood.routing.Router;
+import junit.framework.TestCase;
+
+public class AnnotationProcessorTest extends TestCase {
+    public void testProcessAnnotationsInjectsAndRegistersRoutes() {
+        if (KatanaCore.container.get(UserController.class) == null) {
+            KatanaCore.container.set(UserController.class, new UserController());
+        }
+
+        AnnotationProcessor ap = new AnnotationProcessor();
+        Router router = new Router();
+
+        ap.processAnnotations(KatanaCore.container.classDefinitions(), router);
+
+        UserController ctrl = KatanaCore.container.get(UserController.class);
+        assertNotNull(ctrl.userService);
+        assertNotNull(ctrl.scraper);
+        assertTrue(router.hasRouteWithPath("/test1"));
+        assertTrue(router.hasRouteWithPath("/test2"));
+        assertTrue(router.hasRouteWithPath("/test3"));
+        assertTrue(router.hasRouteWithPath("/scrape"));
+    }
+}


### PR DESCRIPTION
## Summary
- stop printing annotations and other debug info during annotation processing
- remove debug logs from router and userland classes
- clean up `HttpRequestSerializer` console output
- delete stray executable and ignore it

## Testing
- `mvn test` *(fails: `mvn: command not found`)*