### PR TITLE
Load config via classpath resource

### DIFF
--- a/src/main/java/com/norwood/core/FileConfigManager.java
+++ b/src/main/java/com/norwood/core/FileConfigManager.java
@@ -1,32 +1,35 @@
 package com.norwood.core;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class FileConfigManager implements ConfigManager {
-    private final String configFile = "src/main/resources/application.properties";
+    private final String configFile = "application.properties";
     private boolean cached = false;
     private Map<String, String> configMap = new HashMap<>();
 
     @Override
     public void cacheConfig() {
-        configMap = readConfigLines()
-            .collect(Collectors.toMap(
-                line -> line.split("=")[0],
-                line -> line.split("=")[1]
-            ));
-    }
-
-    private Stream<String> readConfigLines() {
-        try {
-            return Files.lines(Path.of(configFile));
+        try (InputStream stream = FileConfigManager.class
+                .getClassLoader()
+                .getResourceAsStream(configFile)) {
+            if (stream == null) {
+                throw new RuntimeException("No config file found at: " + configFile);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                configMap = reader.lines()
+                    .collect(Collectors.toMap(
+                        line -> line.split("=")[0],
+                        line -> line.split("=")[1]
+                    ));
+            }
         } catch (IOException e) {
-            throw new RuntimeException("No config file found at: " + configFile);
+            throw new RuntimeException("Failed to load config file: " + configFile, e);
         }
     }
 

--- a/src/test/java/com/norwood/FileConfigManagerTest.java
+++ b/src/test/java/com/norwood/FileConfigManagerTest.java
@@ -1,0 +1,47 @@
+package com.norwood;
+
+import junit.framework.TestCase;
+
+import com.norwood.core.FileConfigManager;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+public class FileConfigManagerTest extends TestCase {
+    public void testConfigLoadsFromClasspath() {
+        FileConfigManager manager = new FileConfigManager();
+        String value = manager.get("beanRegistryClass");
+        assertEquals("com.norwood.userland.UserBeanRegistry", value);
+    }
+
+    public void testConfigLoadsFromJar() throws Exception {
+        // Create a temporary jar containing the properties file
+        Path tempJar = Files.createTempFile("config", ".jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(tempJar.toFile()))) {
+            jos.putNextEntry(new JarEntry("application.properties"));
+            Path src = Paths.get("src/main/resources/application.properties");
+            Files.copy(src, jos);
+            jos.closeEntry();
+        }
+
+        // Determine location of compiled classes
+        URL classes = FileConfigManager.class.getProtectionDomain().getCodeSource().getLocation();
+        URL[] cp = new URL[] { classes, tempJar.toUri().toURL() };
+        try (URLClassLoader loader = new URLClassLoader(cp)) {
+            Class<?> clazz = Class.forName("com.norwood.core.FileConfigManager", true, loader);
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+            String value = (String) clazz.getMethod("get", String.class).invoke(instance, "beanRegistryClass");
+            assertEquals("com.norwood.userland.UserBeanRegistry", value);
+        }
+
+        Files.deleteIfExists(tempJar);
+    }
+}


### PR DESCRIPTION
## Summary
- load properties using `ClassLoader.getResourceAsStream`
- add tests ensuring config loads from classpath and from jar

## Testing
- `javac @/tmp/sources.txt` *(fails: unnamed variables are a preview feature)*