### PR TITLE
Fix config parsing for values containing equals

### DIFF
--- a/src/main/java/com/norwood/core/FileConfigManager.java
+++ b/src/main/java/com/norwood/core/FileConfigManager.java
@@ -23,9 +23,10 @@ public class FileConfigManager implements ConfigManager {
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
                 configMap = reader.lines()
+                    .map(line -> line.split("=", 2))
                     .collect(Collectors.toMap(
-                        line -> line.split("=")[0],
-                        line -> line.split("=")[1]
+                        parts -> parts[0],
+                        parts -> parts.length > 1 ? parts[1] : ""
                     ));
             }
         } catch (IOException e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 beanRegistryClass=com.norwood.userland.UserBeanRegistry
+complexValue=a=b=c

--- a/src/test/java/com/norwood/FileConfigManagerTest.java
+++ b/src/test/java/com/norwood/FileConfigManagerTest.java
@@ -20,6 +20,9 @@ public class FileConfigManagerTest extends TestCase {
         FileConfigManager manager = new FileConfigManager();
         String value = manager.get("beanRegistryClass");
         assertEquals("com.norwood.userland.UserBeanRegistry", value);
+        // verify values containing '=' characters are preserved
+        String complex = manager.get("complexValue");
+        assertEquals("a=b=c", complex);
     }
 
     public void testConfigLoadsFromJar() throws Exception {
@@ -40,6 +43,8 @@ public class FileConfigManagerTest extends TestCase {
             Object instance = clazz.getDeclaredConstructor().newInstance();
             String value = (String) clazz.getMethod("get", String.class).invoke(instance, "beanRegistryClass");
             assertEquals("com.norwood.userland.UserBeanRegistry", value);
+            String complex = (String) clazz.getMethod("get", String.class).invoke(instance, "complexValue");
+            assertEquals("a=b=c", complex);
         }
 
         Files.deleteIfExists(tempJar);


### PR DESCRIPTION
## Summary
- parse config values using `split("=", 2)` so values with `=` are kept intact
- add new complex entry to example config
- extend tests to ensure complex values are preserved

## Testing
- `mvn -q test` *(fails: command not found)*