### PR TITLE
Support query strings in HttpRequest serialization

### DIFF
--- a/src/main/java/com/norwood/util/HttpRequestSerializer.java
+++ b/src/main/java/com/norwood/util/HttpRequestSerializer.java
@@ -26,7 +26,7 @@ public class HttpRequestSerializer
     }
 
     public static String serialize(HttpRequest req) {
-        return String.format("%s %s HTTP/1.1", req.method(), req.uri().getPath());
+        return String.format("%s %s HTTP/1.1", req.method(), getPath(req.uri()));
     }
     
     public static String getPath(URI uri) {

--- a/src/test/java/com/norwood/AppTest.java
+++ b/src/test/java/com/norwood/AppTest.java
@@ -31,6 +31,14 @@ public class AppTest
         assertEquals(line, HttpRequestSerializer.serialize(req));
     }
 
+    public void testSerializeUnserializeRoundtripWithQuery() {
+        String line = "GET /hello?x=1 HTTP/1.1";
+        HttpRequest req = HttpRequestSerializer.unserialize(line);
+        assertEquals("GET", req.method());
+        assertEquals("/hello?x=1", HttpRequestSerializer.getPath(req.uri()));
+        assertEquals(line, HttpRequestSerializer.serialize(req));
+    }
+
     public void testUnserializeAllMethods() {
         String[] methods = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"};
         for (String method : methods) {


### PR DESCRIPTION
## Summary
- ensure HttpRequestSerializer.serialize keeps query strings
- add test covering query string round‑trip

## Testing
- `javac src/main/java/com/norwood/util/HttpRequestSerializer.java`
- `javac -cp src/main/java src/test/java/com/norwood/AppTest.java` *(fails: package `junit.framework` does not exist)*