### PR TITLE
Remove a.out and ignore future builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/*
 .settings
 .git
 
+a.out


### PR DESCRIPTION
## Summary
- delete stale `a.out`
- add `a.out` to `.gitignore` so it isn't tracked

## Testing
- `mvn -q test` *(fails: `mvn` not found)*